### PR TITLE
Add typescript support

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'react-native-error-boundary' {
+  import React from 'react';
+
+  export type ErrorBoundaryProps = {
+    children: React.ReactNode;
+    FallbackComponent?: React.ComponentType<{ error: Error; resetError: () => void }>;
+    onError?: (error: Error, stackTrace: string) => void;
+  };
+
+  export default class ErrorBoundary extends React.Component<ErrorBoundaryProps> {}
+}


### PR DESCRIPTION
Fixes #11

I don't set up the `types` field on the `package.json` because the `files` field overrides it:

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

> Also note that if your package.json includes the "files" property the "types" property will be ignored. In that case you need to pass your main declaration file to the "files" property as well.