### PR TITLE
🔧 Automate npm publish with a GitHub Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: NPM Publish
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install dependencies 📦
+      run: yarn
+    - name: Publish package to NPM 🚀
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      run: npm publish --token=${{ env.NPM_TOKEN }}


### PR DESCRIPTION
## Description

Hello! 👋🏼 

This PR automates the process of publishing the package to the `npm` registry. Every time that a new tag `v*` is pushed to the repository, automatically the `npm-publish.yml` github workflow will start to publish the package to the registry.
