### PR TITLE
added explicit color to  FallbackComponent's Text

### DIFF
--- a/src/ErrorBoundary/FallbackComponent/styles.js
+++ b/src/ErrorBoundary/FallbackComponent/styles.js
@@ -13,11 +13,13 @@ const styles: any = StyleSheet.create({
   title: {
     fontSize: 48,
     fontWeight: '300',
-    paddingBottom: 16
+    paddingBottom: 16,
+    color: '#000'
   },
   subtitle: {
     fontSize: 32,
-    fontWeight: '800'
+    fontWeight: '800',
+    color: '#000'
   },
   error: {
     paddingVertical: 16

--- a/src/__tests__/__snapshots__/errorBoundary.spec.js.snap
+++ b/src/__tests__/__snapshots__/errorBoundary.spec.js.snap
@@ -33,6 +33,7 @@ exports[`ErrorBoundary when there is an error when FallbackComponent is not defi
     <Text
       style={
         Object {
+          "color": "#000",
           "fontSize": 48,
           "fontWeight": "300",
           "paddingBottom": 16,
@@ -44,6 +45,7 @@ exports[`ErrorBoundary when there is an error when FallbackComponent is not defi
     <Text
       style={
         Object {
+          "color": "#000",
           "fontSize": 32,
           "fontWeight": "800",
         }


### PR DESCRIPTION
Since RN-v0.64 Texts without color style displays as white texts on android.
My app is on v0.64 and FallbackComponent Texts shows white text.

This should fix that unintended behaviour for us.