### PR TITLE
removed $ from readme install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Install
 
 ```bash
-$ yarn add react-native-error-boundary
+yarn add react-native-error-boundary
 ```
 
 ## Usage


### PR DESCRIPTION
$ sign would be copied if user click the copy button which could produce `bash: $: command not found`