### PR TITLE
👷 Update npm publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install dependencies 📦
       run: yarn
     - name: Publish package to NPM 🚀

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Publish package to NPM 🚀
       env:
         NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
-      run: npm publish --token=${{ env.NPM_TOKEN }}
+      run: |
+        npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        npm publish
     - name: Publish GitHub Release 📝
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
## Description

This PR updates the `node-version` to 16 and the authentication method used for running `npm publish`