### PR TITLE
✨ Add `gtag` to docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
         },
         blog: false,
         theme: { customCss: require.resolve('./src/theme/theme.css') },
+        gtag: {
+          trackingID: 'G-TYCHT7C3PQ',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR adds a `gtag` configuration to the documentation site.
