### PR TITLE
🔧 Enable `dependabot` for GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: weekly
       time: "04:00"
     open-pull-requests-limit: 10
+    
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: monthly
+        time: "04:00"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR enables dependabot for GitHub Action dependencies.