### PR TITLE
🏷️ Update `children` type in `ErrorBoundary` with a required `ReactNode`

### DIFF
--- a/src/ErrorBoundary/index.tsx
+++ b/src/ErrorBoundary/index.tsx
@@ -5,7 +5,7 @@ import FallbackComponent, {
 } from './FallbackComponent'
 
 export type Props = {
-  children: Exclude<React.ReactNode, number | string | boolean| null | undefined>,
+  children: Exclude<React.ReactNode, number | string | boolean | null | undefined>,
   FallbackComponent: ComponentType<FallbackComponentProps>,
   onError?: (error: Error, stackTrace: string) => void
 }

--- a/src/ErrorBoundary/index.tsx
+++ b/src/ErrorBoundary/index.tsx
@@ -1,11 +1,11 @@
-import React, { type ComponentType } from 'react'
+import React, { type ComponentType, type ReactNode } from 'react'
 
 import FallbackComponent, {
   type Props as FallbackComponentProps
 } from './FallbackComponent'
 
 export type Props = {
-  children: Exclude<React.ReactNode, number | string | boolean | null | undefined>,
+  children: Exclude<NonNullable<ReactNode>, string | number | boolean>,
   FallbackComponent: ComponentType<FallbackComponentProps>,
   onError?: (error: Error, stackTrace: string) => void
 }

--- a/src/ErrorBoundary/index.tsx
+++ b/src/ErrorBoundary/index.tsx
@@ -5,7 +5,7 @@ import FallbackComponent, {
 } from './FallbackComponent'
 
 export type Props = {
-  children: JSX.Element,
+  children: Exclude<React.ReactNode, number | string | boolean| null | undefined>,
   FallbackComponent: ComponentType<FallbackComponentProps>,
   onError?: (error: Error, stackTrace: string) => void
 }


### PR DESCRIPTION
## Description

My case is something like this:

```js
import {Toasts} from '@backpackapp-io/react-native-toast';
import CodePushUpdateProgress from 'components/codepush';
import ErrorBoundary from 'react-native-error-boundary';

...

<ErrorBoundary>
  <NavigationContainer />
  <CodePushUpdateProgress />
  <Toasts />
</ErrorBoundary>
```
After upgrade to 1.2.0, it throws message `This JSX tag's 'children' prop expects a single child of type 'Element', but multiple children were provided`.

## Demo

<!-- Please insert a preview of your changes here, screenshot/video/preview -->
Before
<img width="831" alt="Screenshot 2023-01-10 at 10 49 40 AM" src="https://user-images.githubusercontent.com/31266357/211457856-b68e8cf2-737b-4407-b694-b6224e164198.png">

After

<img width="831" alt="Screenshot 2023-01-10 at 10 48 16 AM" src="https://user-images.githubusercontent.com/31266357/211457730-e660a84a-bf64-4890-9eeb-2fb41d2af8c7.png">
