### PR TITLE
➖ Remove `@types/react-native` from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.18.2",
     "@types/jest": "^29.4.0",
-    "@types/react-native": "^0.71.2",
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.52.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,13 +1978,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-native@^0.71.2":
-  version "0.71.2"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.71.2.tgz#b8ba52c2fd07d3d64fa87ae5d9b4fbbd3b9cbffd"
-  integrity sha512-RJ0slxB/aVh6gDBZcGusDLIMW+ydsigzOVva9nODPfZApvIY4UgacV5PAlyk/CScJaN7Frh4sZaD9bD73uc9HQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-test-renderer@^18.0.0":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

Since `react-native` 0.71, the `@types/react-native` dependency can be safely removed as it's bundled.

Read more here: https://reactnative.dev/blog/2023/01/12/version-071#typescript-by-default
