### PR TITLE
🔧 fix: restore type compatibility with React 18 by explicitly type annotation for `render` method

### DIFF
--- a/src/ErrorBoundary/index.tsx
+++ b/src/ErrorBoundary/index.tsx
@@ -35,7 +35,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     this.setState({ error: null })
   }
 
-  render() {
+  render(): ReactNode {
     const { FallbackComponent } = this.props
 
     return this.state.error ? (


### PR DESCRIPTION
The types of React 18 and React 19 are quite different.
If no return type is specified the type will be inferred (to the type below).
This caused the types to break for RN on React 18.

ReactNode might be a middle ground that could work for both Versions.
I am not 100% sure if this works for React 19 Apps (in every case).

Types:
```javascript
// React 18:
render18(): ReactNode;

// React 19:
render19(): bigint | React.JSX.Element | Iterable<React.ReactNode> | Promise<string | number | bigint | boolean | React.ReactPortal | React.ReactElement<unknown, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | null | undefined>;

```