### PR TITLE
🏷️ Update `ErrorBoundary` `children` `Props` type

### DIFF
--- a/src/ErrorBoundary/index.tsx
+++ b/src/ErrorBoundary/index.tsx
@@ -1,14 +1,13 @@
-import React, { type ComponentType, type ReactNode } from 'react'
+import React, { type ComponentType, type PropsWithChildren } from 'react'
 
 import FallbackComponent, {
   type Props as FallbackComponentProps,
 } from './FallbackComponent'
 
-export type Props = {
-  children: Exclude<NonNullable<ReactNode>, string | number | boolean>
+export type Props = PropsWithChildren<{
   FallbackComponent: ComponentType<FallbackComponentProps>
   onError?: (error: Error, stackTrace: string) => void
-}
+}>
 
 type State = { error: Error | null }
 


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR updates the `ErrorBoundary` `Props` type to leverage the `children` type from the `react` package.
Related with #930 (will not fix entirely the issue) but it's an improvement on the types.