### PR TITLE
♻️ Move rn-safe-area-context to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "homepage": "https://github.com/carloscuesta/react-native-error-boundary",
   "peerDependencies": {
     "react": ">=16.6.0",
-    "react-native": ">=0.74.0"
+    "react-native": ">=0.74.0",
+    "react-native-safe-area-context": ">=5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",
@@ -118,8 +119,5 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
   },
-  "packageManager": "pnpm@10.0.0",
-  "dependencies": {
-    "react-native-safe-area-context": "5.6.1"
-  }
+  "packageManager": "pnpm@10.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
   .:
     dependencies:
       react-native-safe-area-context:
-        specifier: 5.6.1
+        specifier: '>=5.0.0'
         version: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.2.0)(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
## Description

Closes https://github.com/carloscuesta/react-native-error-boundary/issues/953